### PR TITLE
bug when `max_disp` is not multiple of 16

### DIFF
--- a/submission.py
+++ b/submission.py
@@ -1,5 +1,6 @@
 import argparse
 import cv2
+import math
 from models import hsm
 import numpy as np
 import os
@@ -73,6 +74,8 @@ def main():
         imgsize = imgL_o.shape[:2]
 
         if args.max_disp>0:
+            if args.max_disp % 16 != 0:
+                args.max_disp = 16 * math.floor(args.max_disp/16)
             max_disp = int(args.max_disp)
         else:
             with open(test_left_img[inx].replace('im0.png','calib.txt')) as f:


### PR DESCRIPTION
If `max_disp` is not a multiple of 16 (ex. `2056`), then the 3rd dimensions of features do not match.


```python
# inside forward
        if self.level > 2:
            cost3 = F.upsample(cost5, [left.size()[2],left.size()[3]], mode='bilinear')
        else:
            feat4 = torch.cat((feat5_2x, feat4),dim=1)

            feat4_2x, cost4 = self.decoder4(feat4) # 32
            if self.level > 1:
                cost3 = F.upsample((cost4).unsqueeze(1), [self.disp_reg8.disp.shape[1], left.size()[2],left.size()[3]], mode='trilinear').squeeze(1)
            else:
                # bug here!
                feat3 = torch.cat((feat4_2x, feat3),dim=1)
```